### PR TITLE
Update set-tag for github actions security issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
     # Gets current tag name and puts it into an environment variable GIT_TAG_NAME
     - name: Get tag name
-      uses: olegtarasov/get-tag@v2
+      uses: olegtarasov/get-tag@v2.1
 
     - name: Helm tool installer
       uses: Azure/setup-helm@v1


### PR DESCRIPTION
# Summary

When releasing a tag the github actions deploy failed with the following error [link](https://github.com/Smirl/highheath/runs/1697125079?check_suite_focus=true):

<img width="1657" alt="Screenshot 2021-01-13 at 18 59 04" src="https://user-images.githubusercontent.com/5792870/104496885-7a1a4580-55d1-11eb-947f-9aec6220df09.png">
