### PR TITLE
Add TOKEN_FILE env var to fix Reply-To in emails

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             secretKeyRef:
               name: recaptcha
               key: secret
+        - name: TOKEN_FILE
+          value: token.json
         volumeMounts:
         - mountPath: /credentials.json
           subPath: credentials.json


### PR DESCRIPTION
# Summary

Emails (bookings, contact forms, comments) were sent to people with the name `highheath` but with the email address `smirlie`.

This was because of a bad line of code which is used for testing.

Adding `TOKEN_FILE` environment variable means we will not longer be in testing mode and emails will look to come from highheath@googlemail.com.

## Before

![image](https://user-images.githubusercontent.com/5792870/115988189-61e29b00-a5b0-11eb-8315-7642292f6a71.png)

## After

![image](https://user-images.githubusercontent.com/5792870/115988204-7030b700-a5b0-11eb-99d5-8a9b6e140246.png)
