### PR TITLE
Upgrade hugo to 0.87.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build hugo
-FROM klakegg/hugo:0.74.3-alpine AS hugo
+FROM klakegg/hugo:0.87.0-alpine AS hugo
 COPY . /src
 RUN hugo --minify --cleanDestinationDir
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,9 @@ outputs:
     - HTML
   section:
     - HTML
+
+markup:
+  goldmark:
+    parser:
+      attribute:
+        block: true

--- a/content/prices.md
+++ b/content/prices.md
@@ -1,6 +1,5 @@
 ---
 title: "Prices"
-markup: "mmark"
 menu:
   main:
     weight: 3
@@ -10,12 +9,12 @@ The prices below are per pen per day and are inclusive of arrival and departure 
 
 Please note you must state on the booking form if you plan to collect your cat before 10am, otherwise this day will be charged at the full price.
 
-{.table .pure-table .table-striped .table-responsive}
 Number of cats|Price per Pen per day
 --------------|---------------------
 1|£11.00
 2 cats sharing|£16.00
 3 cats sharing|£23.00
 4 cats sharing|£26.00
+{.table .pure-table .table-striped .table-responsive}
 
 Prices are subject to change without notice.


### PR DESCRIPTION
 # Summary

- upgrade to hugo 0.87.0
- remove `mmark` for table formatting in `prices.md`
- enable attribute support for blocks for add classes to markdown tables
