### PR TITLE
Remove email pages from comment list and better template

### DIFF
--- a/content/comments/failure.md
+++ b/content/comments/failure.md
@@ -1,6 +1,7 @@
 ---
 title: Review Failed
 home_button: true
+hide: true
 ---
 
 Something has gone wrong. Please try again.

--- a/content/comments/success.md
+++ b/content/comments/success.md
@@ -1,7 +1,7 @@
 ---
 title: Thank you for your Review
 home_button: true
-
+hide: true
 ---
 Thank you for writing us a review. 
 

--- a/themes/highheath/layouts/_default/single.html
+++ b/themes/highheath/layouts/_default/single.html
@@ -7,6 +7,10 @@
                 <h1>{{ . }}</h1>
                 <hr>
                 {{ end }}
+                {{ if eq $.Section "comments" }}
+                <h1>{{ .Params.author }}</h1>
+                <h3>{{ .Date.Format "2 January 2006" }}</h3>
+                {{ end }}
                 {{ .Content }}
             </div>
         </div>
@@ -49,6 +53,13 @@
         <div class="row">
             <div class="col-sm-4 col-sm-offset-4">
                 <a href="/" role="button" class="btn btn-lg btn-primary btn-block">Back to the home page</a>
+            </div>
+        </div>
+        {{ end }}
+        {{ if eq $.Section "comments" }}
+        <div class="row">
+            <div class="col-sm-4 col-sm-offset-4">
+                <a onclick="window.history.back()" role="button" class="btn btn-lg btn-primary btn-block">Back</a>
             </div>
         </div>
         {{ end }}

--- a/themes/highheath/layouts/comments/list.html
+++ b/themes/highheath/layouts/comments/list.html
@@ -56,7 +56,7 @@
             </div>
         </div>
         <div class="row">
-            {{ $paginator := .Paginate .Pages 20 }}
+            {{ $paginator := .Paginate (where .Pages ".Params.hide" "!=" true) 20 }}
             <div class="col-sm-12">
                 <nav aria-label="Page navigation" class="text-center">
                     {{ template "_internal/pagination.html" . }}


### PR DESCRIPTION
# Section

- remove the email success/failure pages from the list of comments
- make the comment single page a little prettier
