### PR TITLE
Markdown Render Hook for optionally loading images from assets

### DIFF
--- a/themes/highheath/layouts/_default/_markup/render-image.html
+++ b/themes/highheath/layouts/_default/_markup/render-image.html
@@ -1,0 +1,6 @@
+{{- $image := resources.Get .Destination }}
+{{- if ne $image nil }}
+<img src="{{ $image.RelPermalink }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }} />
+{{- else }}
+<img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }} />
+{{- end }}


### PR DESCRIPTION
# Summary

- ensure that markdown image links can load images from forestry uploads which will go to assets
- also non asset (static) images should work too
