### PR TITLE
Better webp/jpeg support for older browsers. Better gallery ordering.

### DIFF
--- a/content/accommodation/index.md
+++ b/content/accommodation/index.md
@@ -7,24 +7,24 @@ gallery:
 - "/uploads/img_4652.jpg"
 - "/uploads/img_5667.jpg"
 - "/uploads/img_5665.jpg"
-- "/uploads/img_2102.jpg"
+- "/uploads/img_5663.jpg"
 - "/uploads/img_4919.jpg"
 - "/uploads/img_4986.jpg"
+- "/uploads/17.jpg"
 - "/uploads/img_2205.jpg"
-- uploads/17.jpg
+- "/uploads/img_5664.jpg"
 - "/uploads/img_5659.jpg"
 - "/uploads/img_5660.jpg"
 - "/uploads/img_5661.jpg"
-- "/uploads/img_5663.jpg"
-- "/uploads/img_5664.jpg"
+- "/uploads/img_2102.jpg"
 - "/uploads/img_5670.jpg"
 - "/uploads/img_5674.jpg"
-- "/uploads/kitchen.jpg"
 - "/uploads/reception.jpg"
 - "/uploads/img_2128.jpg"
+- "/uploads/kitchen.jpg"
 - "/uploads/img_2250.jpg"
 - "/uploads/img_2266.jpg"
-- uploads/26.jpg
+- "/uploads/26.jpg"
 menu:
   main:
     weight: 2

--- a/themes/highheath/assets/css/style.css
+++ b/themes/highheath/assets/css/style.css
@@ -39,12 +39,17 @@ nav .border{
 #gallery .gallery-container {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: space-between;
 }
 
-#gallery .gallery-container img {
+#gallery .gallery-container picture {
+	flex: 1 0 auto;
+	margin: 5px;
+}
+
+#gallery .gallery-container picture img {
+	width: 100%;
 	height: 300px;
-	margin: 2px;
-	flex-grow: 1;
 	object-fit: cover;
 	max-width: 100%;
 }

--- a/themes/highheath/layouts/_default/single.html
+++ b/themes/highheath/layouts/_default/single.html
@@ -20,14 +20,24 @@
                 <div class="gallery-container">
                     {{- range  $name := . }}
                     {{- $img := resources.Get $name }}
+                    {{- $orientation := 0 }}
+
                     {{- with $img.Exif }}
-                    {{- if eq .Tags.Orientation 6}}
-                    {{- $img = $img.Resize "x300 webp q80 r270" }}
-                    {{- else }}
-                    {{- $img = $img.Resize "x300 webp q80" }}
+                    {{- if .Tags.Orientation}}
+                    {{- $orientation = .Tags.Orientation }}
                     {{- end }}
                     {{- end }}
-                    <img src="{{ $img.RelPermalink }}" alt="{{ $name }}" class="img-fluid flex-grow-1" width="{{ $img.Width }}" height="{{ $img.Height }}">
+
+                    {{- $webp := $img.Resize "x300 webp q80" }}
+                    {{- $jpeg := $img.Resize "x300 jpeg q80" }}
+                    {{- if eq $orientation 6 }}
+                    {{- $webp = $img.Resize "x300 webp q80 r270" }}
+                    {{- $jpeg = $img.Resize "x300 jpeg q80 r270" }}
+                    {{- end }}
+                    <picture>
+                        <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
+                        <img src="{{ $jpeg.RelPermalink }}" alt="{{ $name }}" width="{{ $jpeg.Width }}" height="{{ $jpeg.Height }}">
+                    </picture>
                     {{ end }}
                 </div>
             </div>


### PR DESCRIPTION
# Summary

- reorder images to make them fit better
- move to html5 `picture` flag for webp and jpeg support
- fix bug where images without Exif would not be scaled
