### PR TITLE
Add golangci-lint to workflow. Remove setup-go caching.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,7 +17,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ^1.19
-          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Works with v1.50.1, setting to latest to get future issues
+          version: latest
 
       - name: Test
         run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...


### PR DESCRIPTION
# Summary

- add official golangci-lint action with latest version (tested at the time with `v1.50.1`
- remove caching. It's not very slow and we keep adding extra caches and no reusing them.
- cba to work out why right now