### PR TITLE
Update Dockerfile to Go 1.25 and improve setup docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src
 RUN hugo --minify --cleanDestinationDir
 
 #build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /go/src/app
 COPY . .
 RUN go get -d -v ./...

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ For fast theme development run:
 
 To test forms you will need:
 
-    docker-compose up
+1. First-time setup (see Gmail API Setup and Github API Setup sections below):
+   - Obtain `credentials.json` from Google Cloud Console
+   - Obtain `private-key.pem` from GitHub App settings
+   - Generate `token.dev.json` by running `TOKEN_FILE=token.dev.json go run cmd/highheath/main.go` and completing OAuth flow
+
+2. Start the application:
+   ```bash
+   docker-compose up
+   ```
 
 
 ## Theme layout
@@ -72,9 +80,24 @@ authentication.
 
 For the gmail api, a project [_Website Form Backend_][gmail-console] has been
 created with Oauth2 credentials. `credentials.json` can be downloaded from the
-console. The application should be started where, after authenticating the app,
-a `token.json` will be created. These should not be checked in. A secret in the
-cluster should be created:
+console.
+
+**Initial token setup (required before using docker-compose):**
+
+1. Place `credentials.json` in the project root
+2. Run the app locally to generate the token:
+   ```console
+   TOKEN_FILE=token.dev.json go run cmd/highheath/main.go
+   ```
+3. Follow the authorization URL printed in the console
+4. Complete the OAuth flow in your browser
+5. The token will be saved to `token.dev.json`
+6. Press Ctrl+C to stop the server
+
+After obtaining the token, you can use `docker-compose up` for development.
+These credential files should not be checked in.
+
+For production deployment, a secret in the cluster should be created:
 
 ```console
 kubectl create secret generic gmail -n highheath --from-file=credentials.json --from-file=token.json


### PR DESCRIPTION
# Summary

This pull request updates the project's documentation to clarify the initial setup steps for authentication and updates the Go version used in the Docker build. The most important changes are grouped below:

**Documentation Improvements:**

* Expanded the `README.md` with a clear, step-by-step guide for first-time authentication setup, including obtaining `credentials.json`, `private-key.pem`, and generating `token.dev.json` before running the app with Docker Compose.
* Added detailed instructions for generating the Gmail API OAuth token, including running the app locally, completing the OAuth flow, and using the generated token for development, while emphasizing that credential files should not be checked in.

**Build Environment Update:**

* Updated the Go version in the Dockerfile from `golang:1.23-alpine` to `golang:1.25-alpine` to use a newer version for building the application.